### PR TITLE
Feat(ExplicitCancel): return false to retry explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poll-until-promise",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Try repeatedly for a promise to be resolved",
   "main": "lib/poll-until-promise.js",
   "directories": {
@@ -23,10 +23,16 @@
     "test:coverage": "cross-env jest --coverage && cat ./coverage/lcov.info | coveralls",
     "release": "npm run lint && npm run test:coverage && npm run build"
   },
+  "contributors": [{
+    "name" : "Eden Turgeman",
+    "email" : "edmx0.et@gmail.com",
+    "url" : "https://github.com/EdenTurgeman"
+  }],
   "keywords": [
     "wait",
     "until",
-    "promise"
+    "promise",
+    "test"
   ],
   "author": "Alon Mizrahi",
   "license": "ISC",

--- a/src/poll-until-promise.js
+++ b/src/poll-until-promise.js
@@ -121,15 +121,15 @@ class PollUntil {
     }
     executor
       .then((result) => {
-        if (result) {
-          this.resolve(result);
-          this._isWaiting = false;
-          this._isResolved = true;
-          this._log(`then done waiting with result: ${result}`);
+        if (result === false) {
+          this._log(`then execute again with result: ${result}`);
+          this._executeAgain();
           return;
         }
-        this._log(`then execute again with result: ${result}`);
-        this._executeAgain();
+        this.resolve(result);
+        this._isWaiting = false;
+        this._isResolved = true;
+        this._log(`then done waiting with result: ${result}`);
       })
       .catch((err) => {
         if (this._stopOnFailure) {

--- a/test/poll-until-promise.spec.js
+++ b/test/poll-until-promise.spec.js
@@ -252,7 +252,7 @@ describe('Unit: Wait Until Factory', () => {
           return 5;
         }
         counter += 1;
-        return undefined;
+        return false;
       })
       .then((value) => {
         expect(value).toEqual(5);


### PR DESCRIPTION
Failed and no return value will stop as long as the promise is resolved, return false to cancel or throw an exception. 