### PR TITLE
Add `backoffMaxInterval` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,11 @@ pollUntilPromise
 const options = {
     interval: 100,
     backoffFactor: 1, // Exponential interval increase. Defaults to 1, which means no backoff
+    backoffMaxInterval: 250, // Sets a maximum interval when using backoff. Defaults to the timeout value
     timeout: 1000,
     stopOnFailure: false, // Ignores promise rejections
     verbose: false,
-    message: 'Waiting for time to pass :)', // custom message to display on failure 
+    message: 'Waiting for time to pass :)', // custom message to display on failure
 };
 let pollUntilPromise = new PollUntil(options);
 ```

--- a/__tests__/poll-until-promise.spec.ts
+++ b/__tests__/poll-until-promise.spec.ts
@@ -355,6 +355,26 @@ describe('Unit: Wait Until Factory', () => {
       });
   });
 
+  it('should respect max interval during backoff if defined', async () => {
+    const baseInterval = 10;
+    const backoffFactor = 2;
+    const backoffMaxInterval = 24;
+
+    shouldHaltPromiseResolve = true;
+    tryingAttemptsRemaining = 4;
+
+    const pollUntil = new PollUntil({ backoffFactor, backoffMaxInterval });
+
+    const mockPromise = jest.fn(() => someRandPromise(0));
+
+    return pollUntil
+      .tryEvery(baseInterval)
+      .execute(mockPromise)
+      .then(() => {
+        expect(pollUntil._interval).toEqual(backoffMaxInterval);
+      });
+  });
+
   it('wait for should retry in sync function that throws errors', async () => {
     let counter = 0;
     let error: Error | any = null;


### PR DESCRIPTION
This PR addresses issues https://github.com/AlonMiz/poll-until-promise/issues/22 and https://github.com/AlonMiz/poll-until-promise/issues/23.

I think the use case for this feature is something like pinging an unreachable service or another transient issue. You probably want to set the timeout very high (since you want to reestablish connectivity _eventually_). So you initially backoff gracefully but at some point you just want to ping every X number of minutes. Backing off to hours/days/etc is not helpful.

I ended up setting the default value of `backoffMaxInterval` = `timeout`, which should be safe/not impact any existing usages. I'm not sure a "good" default exists that's less than timeout 🤷 
