### PR TITLE
Add `maxAttempts` and `AbortError`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
   },
   "rules": {
     "@typescript-eslint/lines-between-class-members" : 0,
+    "import/prefer-default-export": 0,
     "no-underscore-dangle": 0,
     "max-len": 0
   }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ waitFor(() => fetch('/get-data'), { interval: 100 })
 
 ### Using async
 ```js
-import { waitFor } from 'poll-until-promise';
+import { waitFor, AbortError } from 'poll-until-promise';
 
 async function waitForDomElement(cssSelector = 'div') {
   try {
@@ -35,7 +35,7 @@ async function waitForDomElement(cssSelector = 'div') {
       if (!element) throw new Error(`failed to find element: ${cssSelector}`);
       return element;
     }, { timeout: 60_000 });
-    
+
     return element;
   } catch (e) {
     console.error('faled to find dom element:', e);
@@ -47,6 +47,12 @@ async function retryFetch(path = '/get-data') {
   try {
     const data = await waitFor(async () => {
       const res = await fetch(path);
+
+      // Stop immediately if the resource doesn't exist
+      if (res.status === 404) {
+        throw new AbortError(res.statusText);
+      }
+
       return res.json();
     }, { timeout: 60_000, interval: 1000 });
   } catch (e) {
@@ -106,6 +112,7 @@ const options = {
     stopOnFailure: false, // Ignores promise rejections
     verbose: false,
     message: 'Waiting for time to pass :)', // custom message to display on failure
+    maxAttempts: 5, // maximum attempts to make (default: no limit). Will still fail to wait if reaching timeout before attempts exhausted
 };
 let pollUntilPromise = new PollUntil(options);
 ```

--- a/__tests__/poll-until-promise.spec.ts
+++ b/__tests__/poll-until-promise.spec.ts
@@ -327,7 +327,7 @@ describe('Unit: Wait Until Factory', () => {
         alon();
       }, options2), options1);
     } catch (e: Error | any) {
-      expect(e.message).toMatch(/Failed to wait after \d+ms: waiting for something\nFailed to wait after \d+ms: waiting for another thing/);
+      expect(e.message).toMatch(/Failed to wait after \d+ms \(total of \d+ attempts\): waiting for something\nFailed to wait after \d+ms \(total of \d+ attempts\): waiting for another thing/);
       expect(e.stack).toMatch(/alon/);
     }
   });
@@ -342,7 +342,7 @@ describe('Unit: Wait Until Factory', () => {
     } catch (e) {
       error = e;
     }
-    expect(error?.message).toMatch(/^Failed to wait after \d+ms: waiting for something\nsome error message$/);
+    expect(error?.message).toMatch(/^Failed to wait after \d+ms \(total of \d+ attempts\): waiting for something\nsome error message$/);
   });
 
   it('wait for should save the original stacktrace', async () => {
@@ -356,7 +356,7 @@ describe('Unit: Wait Until Factory', () => {
     } catch (e) {
       error = e;
     }
-    expect(error?.message).toMatch(/^Failed to wait after \d+ms: waiting for something$/);
+    expect(error?.message).toMatch(/^Failed to wait after \d+ms \(total of \d+ attempts\): waiting for something$/);
     expect(error?.stack).toMatch(/customFunction/);
   });
 
@@ -444,7 +444,7 @@ describe('Unit: Wait Until Factory', () => {
 
     const mockPromise = jest.fn().mockRejectedValue(error);
 
-    await expect(pollUntil.execute(mockPromise)).rejects.toThrow('Operation unsuccessful after 3 attempts\nwhoops');
+    await expect(pollUntil.execute(mockPromise)).rejects.toThrow(/Operation unsuccessful after 3 attempts \(total of \d+ms\)\nwhoops/);
   });
 
   it('should not fail if max attempts not exceeded', async () => {

--- a/__tests__/poll-until-promise.spec.ts
+++ b/__tests__/poll-until-promise.spec.ts
@@ -1,4 +1,6 @@
-import { IWaitForOptions, PollUntil, waitFor } from '../src';
+import {
+  AbortError, IWaitForOptions, PollUntil, waitFor,
+} from '../src';
 
 describe('Unit: Wait Until Factory', () => {
   let options: IWaitForOptions = {
@@ -178,22 +180,68 @@ describe('Unit: Wait Until Factory', () => {
       });
   });
 
-  it('should fail wait after timeout', (done) => {
+  it('should fail wait after timeout when stopOnFailure is false', async () => {
     const pollUntil = new PollUntil();
-    shouldHaltPromiseResolve = true;
-    shouldRejectAfterHalt = true;
     const errorContent = 'error abcdefg';
     const specificFailedError = new Error(errorContent);
-    pollUntil
-      .tryEvery(1)
-      .stopAfter(3000)
-      .stopOnFailure(false)
-      .execute(() => Promise.reject(specificFailedError))
-      .catch((error) => {
-        expect(error.message).toContain('Failed to wait');
-        expect(error.message).toContain(errorContent);
-        done();
-      });
+    const mockPromise = jest.fn(() => Promise.reject(specificFailedError));
+
+    expect.assertions(3);
+    try {
+      await pollUntil
+        .tryEvery(1)
+        .stopAfter(50)
+        .stopOnFailure(false)
+        .execute(mockPromise);
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).toContain('Failed to wait');
+      expect(error.message).toContain(errorContent);
+      expect(mockPromise.mock.calls.length).toBeGreaterThan(1);
+    }
+  });
+
+  it('should fail immediately for AbortError when stopOnFailure is false -- passing Error arg', async () => {
+    const pollUntil = new PollUntil();
+    const errorContent = 'error abcdefg';
+    const specificFailedError = new Error(errorContent);
+    const abortError = new AbortError(specificFailedError);
+    const mockPromise = jest.fn(() => Promise.reject(abortError));
+
+    expect.assertions(3);
+    try {
+      await pollUntil
+        .tryEvery(1)
+        .stopAfter(50)
+        .stopOnFailure(false)
+        .execute(mockPromise);
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).not.toContain('Failed to wait');
+      expect(error.message).toContain(errorContent);
+      expect(mockPromise.mock.calls.length).toBe(1);
+    }
+  });
+
+  it('should fail immediately for AbortError when stopOnFailure is false -- passing string arg', async () => {
+    const pollUntil = new PollUntil();
+    const errorContent = 'error abcdefg';
+    const abortError = new AbortError(errorContent);
+    const mockPromise = jest.fn(() => Promise.reject(abortError));
+
+    expect.assertions(3);
+    try {
+      await pollUntil
+        .tryEvery(1)
+        .stopAfter(50)
+        .stopOnFailure(false)
+        .execute(mockPromise);
+    } catch (err) {
+      const error = err as Error;
+      expect(error.message).not.toContain('Failed to wait');
+      expect(error.message).toContain(errorContent);
+      expect(mockPromise.mock.calls.length).toBe(1);
+    }
   });
 
   it('should execute a second waiting when waiting is done (exceeded timeout) but not resolved', (done) => {
@@ -388,5 +436,26 @@ describe('Unit: Wait Until Factory', () => {
     }
     expect(counter).toBeGreaterThan(1);
     expect(error).not.toBeNull();
+  });
+
+  it('should fail if max attempts exceeded', async () => {
+    const pollUntil = new PollUntil({ maxAttempts: 3, interval: 1 });
+    const error = new Error('whoops');
+
+    const mockPromise = jest.fn().mockRejectedValue(error);
+
+    await expect(pollUntil.execute(mockPromise)).rejects.toThrow('Operation unsuccessful after 3 attempts\nwhoops');
+  });
+
+  it('should not fail if max attempts not exceeded', async () => {
+    const pollUntil = new PollUntil({ maxAttempts: 3, interval: 1 });
+    const error = new Error('whoops');
+
+    const mockPromise = jest.fn()
+      .mockRejectedValueOnce(error)
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue({ fake: 'result' });
+
+    expect(await pollUntil.execute(mockPromise)).toEqual({ fake: 'result' });
   });
 });

--- a/src/abort.ts
+++ b/src/abort.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line import/prefer-default-export
+export class AbortError extends Error {
+  cause: Error;
+
+  constructor(cause: Error | string) {
+    super(typeof cause === 'string' ? cause : cause.message);
+    this.cause = typeof cause === 'string' ? new Error(cause) : cause;
+  }
+}

--- a/src/abort.ts
+++ b/src/abort.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export class AbortError extends Error {
   cause: Error;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export {
   IWaitForOptions, PollUntil, waitFor, IExecuteFunction,
 } from './poll-until-promise';
+export { AbortError } from './abort';

--- a/src/poll-until-promise.ts
+++ b/src/poll-until-promise.ts
@@ -1,3 +1,5 @@
+import { AbortError } from './abort';
+
 const ERRORS = {
   NOT_FUNCTION: 'Your executor is not a function. functions and promises are valid.',
   FAILED_TO_WAIT: 'Failed to wait',
@@ -26,11 +28,13 @@ export interface IWaitForOptions {
   backoffFactor?: number
   backoffMaxInterval?: number
   verbose?: boolean
+  maxAttempts?: number
 }
 
 export class PollUntil {
   _interval: number;
   _timeout: number;
+  _attemptCount: number;
   private _stopOnFailure: boolean;
   private readonly _backoffFactor: number;
   private readonly _backoffMaxInterval: number;
@@ -38,6 +42,7 @@ export class PollUntil {
   private readonly originalStacktraceError: Error;
   private readonly _userMessage: string;
   private readonly _verbose: boolean;
+  private readonly _maxAttempts: number | undefined;
   private _isWaiting: boolean;
   private _isResolved: boolean;
   private _executeFn: IExecuteFunction;
@@ -55,9 +60,11 @@ export class PollUntil {
     backoffFactor = 1,
     backoffMaxInterval,
     message = '',
+    maxAttempts,
   }:IWaitForOptions = {}) {
     this._interval = interval;
     this._timeout = timeout;
+    this._attemptCount = 1;
     this._stopOnFailure = stopOnFailure;
     this._isWaiting = false;
     this._isResolved = false;
@@ -67,6 +74,7 @@ export class PollUntil {
     this._Console = console;
     this._backoffFactor = backoffFactor;
     this._backoffMaxInterval = backoffMaxInterval || timeout;
+    this._maxAttempts = maxAttempts;
     this.start = +Date.now();
   }
 
@@ -123,7 +131,11 @@ export class PollUntil {
   }
 
   _shouldStopTrying() {
-    return this._timeFromStart() > this._timeout;
+    return this._timeFromStart() > this._timeout || this._attemptsExhausted();
+  }
+
+  _attemptsExhausted() {
+    return this._maxAttempts !== undefined && this._attemptCount > this._maxAttempts;
   }
 
   _executeAgain() {
@@ -131,11 +143,14 @@ export class PollUntil {
     const currentInterval = this._interval;
     const nextInterval = currentInterval * this._backoffFactor;
     this._interval = (nextInterval > this._backoffMaxInterval) ? this._backoffMaxInterval : nextInterval;
+    this._attemptCount += 1;
     setTimeout(this._runFunction.bind(this), currentInterval);
   }
 
   _failedToWait() {
-    let waitErrorText = `${ERRORS.FAILED_TO_WAIT} after ${this._timeFromStart()}ms`;
+    let waitErrorText = this._attemptsExhausted()
+      ? `Operation unsuccessful after ${this._maxAttempts} attempts`
+      : `${ERRORS.FAILED_TO_WAIT} after ${this._timeFromStart()}ms`;
     if (this._userMessage) waitErrorText = `${waitErrorText}: ${this._userMessage}`;
     if (this._lastError) {
       this._lastError.message = `${waitErrorText}\n${this._lastError.message}`;
@@ -171,6 +186,10 @@ export class PollUntil {
         this._log(`then done waiting with result: ${result}`);
       })
       .catch((err: Error) => {
+        if (err instanceof AbortError) {
+          this._log(`aborted with err: ${err.cause}`);
+          return this.reject?.(err.cause);
+        }
         if (this._stopOnFailure) {
           this._log(`stopped on failure with err: ${err}`);
           return this.reject?.(err);


### PR DESCRIPTION
See issue https://github.com/AlonMiz/poll-until-promise/issues/27

This adds following:
- New option `maxAttempts` (default: no limit) -- Fail if operation not resolved properly after `maxAttempts` attempts. Note this does not circumvent `timeout`, the first reached will win.
- `AbortError` -- when thrown, stop polling immediately, even when `stopOnFailure===false`.